### PR TITLE
Better string output

### DIFF
--- a/lib/psych/visitors/yaml_tree.rb
+++ b/lib/psych/visitors/yaml_tree.rb
@@ -278,7 +278,7 @@ module Psych
         quote = true
         style = Nodes::Scalar::PLAIN
         tag   = nil
-        str   = o.strip
+        str   = o
 
         if binary?(o)
           str   = [o].pack('m').chomp
@@ -287,18 +287,15 @@ module Psych
           style = Nodes::Scalar::LITERAL
           plain = false
           quote = false
-        elsif str =~ /\n/
-          str << $/
+        elsif o =~ /\n[^\Z]/  # match \n except blank line at the end of string
           style = Nodes::Scalar::LITERAL
-        elsif @options[:line_width] && @options[:line_width] < str.length
-          str << $/
+        elsif o.length > line_width
           style = Nodes::Scalar::FOLDED
+          o << "\n" unless o =~ /\n\Z/  # to avoid non-default chomping indicator
         elsif o =~ /^\W[^"]*$/
           style = Nodes::Scalar::DOUBLE_QUOTED
-        else
-          unless String === @ss.tokenize(o)
-            style = Nodes::Scalar::SINGLE_QUOTED
-          end
+        elsif not String === @ss.tokenize(o)
+          style = Nodes::Scalar::SINGLE_QUOTED
         end
 
         ivars = find_ivars o
@@ -523,6 +520,10 @@ module Psych
           @emitter.scalar("#{iv.to_s.sub(/^@/, '')}", nil, nil, true, false, Nodes::Scalar::ANY)
           accept target.instance_variable_get(iv)
         end
+      end
+
+      def line_width
+        @options[:line_width] || Float::INFINITY
       end
     end
   end

--- a/lib/psych/visitors/yaml_tree.rb
+++ b/lib/psych/visitors/yaml_tree.rb
@@ -278,7 +278,7 @@ module Psych
         quote = true
         style = Nodes::Scalar::PLAIN
         tag   = nil
-        str   = o
+        str   = o.strip
 
         if binary?(o)
           str   = [o].pack('m').chomp
@@ -287,8 +287,12 @@ module Psych
           style = Nodes::Scalar::LITERAL
           plain = false
           quote = false
-        elsif o =~ /\n/
+        elsif str =~ /\n/
+          str << $/
           style = Nodes::Scalar::LITERAL
+        elsif @options[:line_width] && @options[:line_width] < str.length
+          str << $/
+          style = Nodes::Scalar::FOLDED
         elsif o =~ /^\W[^"]*$/
           style = Nodes::Scalar::DOUBLE_QUOTED
         else

--- a/test/psych/test_psych.rb
+++ b/test/psych/test_psych.rb
@@ -57,7 +57,7 @@ class TestPsych < Psych::TestCase
   end
 
   def test_dump_stream
-    things = [22, "foo \n", {}]
+    things = [22, "foo", {}]
     stream = Psych.dump_stream(*things)
     assert_equal things, Psych.load_stream(stream)
   end

--- a/test/psych/test_string.rb
+++ b/test/psych/test_string.rb
@@ -24,6 +24,30 @@ module Psych
       assert_match(/---\s*"/, yaml)
     end
 
+    def test_plain_when_shorten_than_line_width
+      str = "Lorem ipsum"
+      yaml = Psych.dump str, {line_width: 12}
+      assert_match /---\s*[^>|]+\n/, yaml
+    end
+
+    def test_folded_when_longer_than_line_width_and_no_newlines
+      str = "Lorem ipsum dolor sit amet, consectetur"
+      yaml = Psych.dump str, {line_width: 12}
+      assert_match /---\s*>\n(.*\n){3}\Z/, yaml
+    end
+
+    def test_folded_when_longer_than_line_width_and_trailing_newline
+      str = "Lorem ipsum dolor sit\n"
+      yaml = Psych.dump str, {line_width: 12}
+      assert_match /---\s*>\n(.*\n){2}\Z/, yaml
+    end
+
+    def test_literal_when_inner_newline
+      str = "Lorem ipsum\ndolor\n"
+      yaml = Psych.dump str, {line_width: 12}
+      assert_match /---\s*|\n(.*\n){2}\Z/, yaml
+    end
+
     def test_cycle_x
       str = X.new 'abc'
       assert_cycle str


### PR DESCRIPTION
Actually, string that in origin was like
```yaml
a: >
  some
  inline
  content
```

Will be output as:
```yaml
a: |
  some inline content
```

Instead with this edit, will be output accordingly with `line_width` option:
```yaml
# line_width = 100
a: some inline content

# line_width = 11
a: >
  some inline
  content
```

It's not that big of a change, but I think it's nice to have, especially for meticulous people like me :)