### PR TITLE
Use appropriate style for serialized strings (replaces #195)

### DIFF
--- a/lib/psych/visitors/yaml_tree.rb
+++ b/lib/psych/visitors/yaml_tree.rb
@@ -62,13 +62,14 @@ module Psych
 
       def initialize emitter, ss, options
         super()
-        @started  = false
-        @finished = false
-        @emitter  = emitter
-        @st       = Registrar.new
-        @ss       = ss
-        @options  = options
-        @coders   = []
+        @started    = false
+        @finished   = false
+        @emitter    = emitter
+        @st         = Registrar.new
+        @ss         = ss
+        @options    = options
+        @line_width = options[:line_width]
+        @coders     = []
 
         @dispatch_cache = Hash.new do |h,klass|
           method = "visit_#{(klass.name || '').split('::').join('_')}"
@@ -316,7 +317,7 @@ module Psych
           tag   = 'tag:yaml.org,2002:str'
           plain = false
           quote = false
-        elsif line_width != 0 && o.length > line_width
+        elsif @line_width && o.length > @line_width
           style = Nodes::Scalar::FOLDED
           o += "\n" unless o =~ /\n\Z/  # to avoid non-default chomping indicator
         elsif o =~ /^[^[:word:]][^"]*$/
@@ -588,10 +589,6 @@ module Psych
           @emitter.scalar("#{iv.to_s.sub(/^@/, '')}", nil, nil, true, false, Nodes::Scalar::ANY)
           accept target.instance_variable_get(iv)
         end
-      end
-
-      def line_width
-        @line_width ||= (@options[:line_width] || 0)
       end
     end
   end

--- a/lib/psych/visitors/yaml_tree.rb
+++ b/lib/psych/visitors/yaml_tree.rb
@@ -309,19 +309,20 @@ module Psych
           style = Nodes::Scalar::LITERAL
           plain = false
           quote = false
-        elsif o =~ /\n/
+        elsif o =~ /\n[^\Z]/  # match \n except blank line at the end of string
           style = Nodes::Scalar::LITERAL
         elsif o == '<<'
           style = Nodes::Scalar::SINGLE_QUOTED
           tag   = 'tag:yaml.org,2002:str'
           plain = false
           quote = false
+        elsif line_width != 0 && o.length > line_width
+          style = Nodes::Scalar::FOLDED
+          o += "\n" unless o =~ /\n\Z/  # to avoid non-default chomping indicator
         elsif o =~ /^[^[:word:]][^"]*$/
           style = Nodes::Scalar::DOUBLE_QUOTED
-        else
-          unless String === @ss.tokenize(o)
-            style = Nodes::Scalar::SINGLE_QUOTED
-          end
+        elsif not String === @ss.tokenize(o)
+          style = Nodes::Scalar::SINGLE_QUOTED
         end
 
         ivars = find_ivars o
@@ -587,6 +588,10 @@ module Psych
           @emitter.scalar("#{iv.to_s.sub(/^@/, '')}", nil, nil, true, false, Nodes::Scalar::ANY)
           accept target.instance_variable_get(iv)
         end
+      end
+
+      def line_width
+        @line_width ||= (@options[:line_width] || 0)
       end
     end
   end

--- a/lib/psych/visitors/yaml_tree.rb
+++ b/lib/psych/visitors/yaml_tree.rb
@@ -319,7 +319,6 @@ module Psych
           quote = false
         elsif @line_width && o.length > @line_width
           style = Nodes::Scalar::FOLDED
-          o += "\n" unless o =~ /\n\Z/  # to avoid non-default chomping indicator
         elsif o =~ /^[^[:word:]][^"]*$/
           style = Nodes::Scalar::DOUBLE_QUOTED
         elsif not String === @ss.tokenize(o)

--- a/lib/psych/visitors/yaml_tree.rb
+++ b/lib/psych/visitors/yaml_tree.rb
@@ -301,10 +301,9 @@ module Psych
         quote = true
         style = Nodes::Scalar::PLAIN
         tag   = nil
-        str   = o
 
         if binary?(o)
-          str   = [o].pack('m').chomp
+          o     = [o].pack('m').chomp
           tag   = '!binary' # FIXME: change to below when syck is removed
           #tag   = 'tag:yaml.org,2002:binary'
           style = Nodes::Scalar::LITERAL
@@ -333,14 +332,14 @@ module Psych
             plain = false
             quote = false
           end
-          @emitter.scalar str, nil, tag, plain, quote, style
+          @emitter.scalar o, nil, tag, plain, quote, style
         else
           maptag = '!ruby/string'
           maptag << ":#{o.class}" unless o.class == ::String
 
           register o, @emitter.start_mapping(nil, maptag, false, Nodes::Mapping::BLOCK)
           @emitter.scalar 'str', nil, nil, true, false, Nodes::Scalar::ANY
-          @emitter.scalar str, nil, tag, plain, quote, style
+          @emitter.scalar o, nil, tag, plain, quote, style
 
           dump_ivars o
 

--- a/test/psych/test_string.rb
+++ b/test/psych/test_string.rb
@@ -34,6 +34,30 @@ module Psych
       assert_match(/---\s*"/, yaml)
     end
 
+    def test_plain_when_shorten_than_line_width
+      str = "Lorem ipsum"
+      yaml = Psych.dump str, line_width: 12
+      assert_match /---\s*[^>|]+\n/, yaml
+    end
+
+    def test_folded_when_longer_than_line_width_and_no_newlines
+      str = "Lorem ipsum dolor sit amet, consectetur"
+      yaml = Psych.dump str, line_width: 12
+      assert_match /---\s*>\n(.*\n){3}\Z/, yaml
+    end
+
+    def test_folded_when_longer_than_line_width_and_trailing_newline
+      str = "Lorem ipsum dolor sit\n"
+      yaml = Psych.dump str, line_width: 12
+      assert_match /---\s*>\n(.*\n){2}\Z/, yaml
+    end
+
+    def test_literal_when_inner_newline
+      str = "Lorem ipsum\ndolor\n"
+      yaml = Psych.dump str, line_width: 12
+      assert_match /---\s*|\n(.*\n){2}\Z/, yaml
+    end
+
     def test_cycle_x
       str = X.new 'abc'
       assert_cycle str

--- a/test/psych/test_string.rb
+++ b/test/psych/test_string.rb
@@ -30,32 +30,54 @@ module Psych
     end
 
     def test_doublequotes_when_there_is_a_single
-      yaml = Psych.dump "@123'abc"
-      assert_match(/---\s*"/, yaml)
+      str = "@123'abc"
+      yaml = Psych.dump str
+      assert_match /---\s*"/, yaml
+      assert_equal str, Psych.load(yaml)
     end
 
-    def test_plain_when_shorten_than_line_width
+    def test_plain_when_shorten_than_line_width_and_no_final_line_break
       str = "Lorem ipsum"
       yaml = Psych.dump str, line_width: 12
       assert_match /---\s*[^>|]+\n/, yaml
+      assert_equal str, Psych.load(yaml)
     end
 
-    def test_folded_when_longer_than_line_width_and_no_newlines
-      str = "Lorem ipsum dolor sit amet, consectetur"
+    def test_plain_when_shorten_than_line_width_and_with_final_line_break
+      str = "Lorem ipsum\n"
       yaml = Psych.dump str, line_width: 12
-      assert_match /---\s*>\n(.*\n){3}\Z/, yaml
+      assert_match /---\s*[^>|]+\n/, yaml
+      assert_equal str, Psych.load(yaml)
     end
 
-    def test_folded_when_longer_than_line_width_and_trailing_newline
+    def test_folded_when_longer_than_line_width_and_with_final_line_break
       str = "Lorem ipsum dolor sit\n"
       yaml = Psych.dump str, line_width: 12
       assert_match /---\s*>\n(.*\n){2}\Z/, yaml
+      assert_equal str, Psych.load(yaml)
     end
 
-    def test_literal_when_inner_newline
+    # http://yaml.org/spec/1.2/2009-07-21/spec.html#id2593651
+    def test_folded_strip_when_longer_than_line_width_and_no_newlines
+      str = "Lorem ipsum dolor sit amet, consectetur"
+      yaml = Psych.dump str, line_width: 12
+      assert_match /---\s*>-\n(.*\n){3}\Z/, yaml
+      assert_equal str, Psych.load(yaml)
+    end
+
+    def test_literal_when_inner_and_final_line_break
       str = "Lorem ipsum\ndolor\n"
       yaml = Psych.dump str, line_width: 12
       assert_match /---\s*|\n(.*\n){2}\Z/, yaml
+      assert_equal str, Psych.load(yaml)
+    end
+
+    # http://yaml.org/spec/1.2/2009-07-21/spec.html#id2593651
+    def test_literal_strip_when_inner_line_break_and_no_final_line_break
+      str = "Lorem ipsum\ndolor"
+      yaml = Psych.dump str, line_width: 12
+      assert_match /---\s*|-\n(.*\n){2}\Z/, yaml
+      assert_equal str, Psych.load(yaml)
     end
 
     def test_cycle_x


### PR DESCRIPTION
This is fixed and squashed #195 updated to the current master.

---

When psych parses YAML with string in the folded style as:

```yaml
a: >
  some
  inline
  content
```

and serializes it back to YAML,
then it renders the string in the literal style instead:

```yaml
a: |
  some inline content
```

This patch fixes this behaviour. When a string doesn't contain newlines (blank line at the end is ignored) and it's not necessary to be quoted, then it will use plain style or folded style according to its length and the `line_width` option.

```yaml
# line_width = 100
a: some inline content

# line_width = 11
a: >
  some inline
  content
```