### PR TITLE
Fix CVE-2014-9130

### DIFF
--- a/ext/psych/yaml/scanner.c
+++ b/ext/psych/yaml/scanner.c
@@ -1106,13 +1106,6 @@ yaml_parser_save_simple_key(yaml_parser_t *parser)
             && parser->indent == (ptrdiff_t)parser->mark.column);
 
     /*
-     * A simple key is required only when it is the first token in the current
-     * line.  Therefore it is always allowed.  But we add a check anyway.
-     */
-
-    assert(parser->simple_key_allowed || !required);    /* Impossible. */
-
-    /*
      * If the current position may start a simple key, save it.
      */
 


### PR DESCRIPTION
See https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2014-9130

This is already fixed in libyaml via this patch:

https://bitbucket.org/xi/libyaml/commits/2b9156756423e967cfd09a61d125d883fca6f4f2