### PR TITLE
Fix mappings with !str tags

### DIFF
--- a/lib/psych/visitors/to_ruby.rb
+++ b/lib/psych/visitors/to_ruby.rb
@@ -61,7 +61,7 @@ module Psych
         case o.tag
         when '!binary', 'tag:yaml.org,2002:binary'
           o.value.unpack('m').first
-        when /^!(?:str|ruby\/string)(?::(.*))?/, 'tag:yaml.org,2002:str'
+        when /^!(?:str|ruby\/string)(?::(.*))?$/, 'tag:yaml.org,2002:str'
           klass = resolve_class($1)
           if klass
             klass.allocate.replace o.value
@@ -208,7 +208,7 @@ module Psych
             obj
           end
 
-        when /^!(?:str|ruby\/string)(?::(.*))?/, 'tag:yaml.org,2002:str'
+        when /^!(?:str|ruby\/string)(?::(.*))?$/, 'tag:yaml.org,2002:str'
           klass   = resolve_class($1)
           members = {}
           string  = nil

--- a/test/psych/visitors/test_to_ruby.rb
+++ b/test/psych/visitors/test_to_ruby.rb
@@ -321,6 +321,13 @@ description:
         assert_equal %w{ foo foo }, list
         assert_equal list[0].object_id, list[1].object_id
       end
+
+      def test_mapping_with_str_tag
+        mapping = Nodes::Mapping.new(nil, '!strawberry')
+        mapping.children << Nodes::Scalar.new('foo')
+        mapping.children << Nodes::Scalar.new('bar')
+        assert_equal({'foo' => 'bar'}, mapping.to_ruby)
+      end
     end
   end
 end


### PR DESCRIPTION
Currently, Psych assumes that any mapping with a tag beginning with '!str' is a string. For example, loading the following document would fail:
```yaml
---
map: !strict
  foo: bar
  baz: qux
```
This PR changes that behaviour so that tags which begin with '!str' are not necessarily interpreted as string tags. This allows one to load documents which make use of tags such as e.g. '!strawberry' or '!strange' without error. This doesn't change the behaviour of '!str' (when matched exactly) or '!ruby/string', or of their '!str:foo' and '!ruby/string:foo' variants.