### PR TITLE
potential memory leak

### DIFF
--- a/ext/psych/psych_emitter.c
+++ b/ext/psych/psych_emitter.c
@@ -50,14 +50,13 @@ static const rb_data_type_t psych_emitter_type = {
 static VALUE allocate(VALUE klass)
 {
     yaml_emitter_t * emitter;
-
-    emitter = xmalloc(sizeof(yaml_emitter_t));
+    VALUE obj = TypedData_Make_Struct(klass, yaml_emitter_t, &psych_emitter_type, emitter);
 
     yaml_emitter_initialize(emitter);
     yaml_emitter_set_unicode(emitter, 1);
     yaml_emitter_set_indent(emitter, 2);
 
-    return TypedData_Wrap_Struct(klass, &psych_emitter_type, emitter);
+    return obj;
 }
 
 /* call-seq: Psych::Emitter.new(io, options = Psych::Emitter::OPTIONS)

--- a/ext/psych/psych_parser.c
+++ b/ext/psych/psych_parser.c
@@ -70,11 +70,11 @@ static const rb_data_type_t psych_parser_type = {
 static VALUE allocate(VALUE klass)
 {
     yaml_parser_t * parser;
+    VALUE obj = TypedData_Make_Struct(klass, yaml_parser_t, &psych_parser_type, parser);
 
-    parser = xmalloc(sizeof(yaml_parser_t));
     yaml_parser_initialize(parser);
 
-    return TypedData_Wrap_Struct(klass, &psych_parser_type, parser);
+    return obj;
 }
 
 static VALUE make_exception(yaml_parser_t * parser, VALUE path)


### PR DESCRIPTION
Fixes potential potential memory leak by allocating structs with making new wrapper objects.

Merges:
ruby/ruby@5924f9a