### PR TITLE
YAML.dump fails to write a file with UTF-8 string

### DIFF
--- a/ext/psych/psych_emitter.c
+++ b/ext/psych/psych_emitter.c
@@ -15,7 +15,11 @@ static void emit(yaml_emitter_t * emitter, yaml_event_t * event)
 static int writer(void *ctx, unsigned char *buffer, size_t size)
 {
     VALUE io = (VALUE)ctx;
+#ifdef HAVE_RUBY_ENCODING_H
+    VALUE str = rb_enc_str_new((const char *)buffer, (long)size, rb_utf8_encoding());
+#else
     VALUE str = rb_str_new((const char *)buffer, (long)size);
+#endif
     VALUE wrote = rb_funcall(io, id_write, 1, str);
     return (int)NUM2INT(wrote);
 }

--- a/test/psych/test_encoding.rb
+++ b/test/psych/test_encoding.rb
@@ -249,6 +249,15 @@ module Psych
       assert_encodings @utf8, @handler.strings
     end
 
+    def test_dump_non_ascii_string_to_file
+      Tempfile.create(['utf8', 'yml'], :encoding => 'UTF-8') do |t|
+        h = {'one' => 'いち'}
+        Psych.dump(h, t)
+        t.close
+        assert_equal h, Psych.load_file(t.path)
+      end
+    end
+
     private
     def assert_encodings encoding, strings
       strings.each do |str|


### PR DESCRIPTION
I got Encoding::UndefinedConversionError when dumping a hash containing Japanese UTF-8 string.to a file. See test code in the change, http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/50219 and http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-list/50220 .