### PR TITLE
Use a constant to avoid thousands of String allocations of "<<"

### DIFF
--- a/lib/psych/visitors/to_ruby.rb
+++ b/lib/psych/visitors/to_ruby.rb
@@ -330,12 +330,13 @@ module Psych
         list
       end
 
+      SHOVEL = '<<'
       def revive_hash hash, o
         o.children.each_slice(2) { |k,v|
           key = accept(k)
           val = accept(v)
 
-          if key == '<<' && k.tag != "tag:yaml.org,2002:str"
+          if key == SHOVEL && k.tag != "tag:yaml.org,2002:str"
             case v
             when Nodes::Alias, Nodes::Mapping
               begin


### PR DESCRIPTION
Example script:

```ruby
require 'allocation_tracer'

ObjectSpace::AllocationTracer.setup(%i{path line type})

require 'net/http'
yaml = Net::HTTP.get(URI('https://raw.githubusercontent.com/ManageIQ/manageiq/master/spec/tools/scvmm_data/get_inventory_output_hash.yml'))

require 'yaml'
result = ObjectSpace::AllocationTracer.trace do
  YAML.load(yaml)
end

result.sort_by{|k, v| k}.each{|k, v|
  puts ([v[0]]+k).join("\t")
}
```

With the example above, this change avoids creating 22,000+ String objects as seen below:

**Before, running master at 9055469038 and rake install_gem**
```
$ ruby benchmark_allocations.rb | grep T_STRING | sort -nr | head -n 10
43444 /Users/joerafaniello/.gem/ruby/2.2.3/gems/psych-2.0.15/lib/psych.rb 376 T_STRING
22439 /Users/joerafaniello/.gem/ruby/2.2.3/gems/psych-2.0.15/lib/psych/visitors/to_ruby.rb  338 T_STRING
7082  /Users/joerafaniello/.gem/ruby/2.2.3/gems/psych-2.0.15/lib/psych/scalar_scanner.rb  105 T_STRING
5308  /Users/joerafaniello/.gem/ruby/2.2.3/gems/psych-2.0.15/lib/psych/scalar_scanner.rb  40  T_STRING
3339  /Users/joerafaniello/.gem/ruby/2.2.3/gems/psych-2.0.15/lib/psych/scalar_scanner.rb  83  T_STRING
3259  /Users/joerafaniello/.gem/ruby/2.2.3/gems/psych-2.0.15/lib/psych/scalar_scanner.rb  54  T_STRING
3014  /Users/joerafaniello/.gem/ruby/2.2.3/gems/psych-2.0.15/lib/psych/scalar_scanner.rb  116 T_STRING
3010  /Users/joerafaniello/.gem/ruby/2.2.3/gems/psych-2.0.15/lib/psych/scalar_scanner.rb  129 T_STRING
3001  /Users/joerafaniello/.gem/ruby/2.2.3/gems/psych-2.0.15/lib/psych/scalar_scanner.rb  137 T_STRING
2409  /Users/joerafaniello/.gem/ruby/2.2.3/gems/psych-2.0.15/lib/psych/scalar_scanner.rb  126 T_STRING
```

**After this commit and rake install_gem**
```
$ ruby benchmark_allocations.rb | grep T_STRING | sort -nr | head -n 10
43444 /Users/joerafaniello/.gem/ruby/2.2.3/gems/psych-2.0.15/lib/psych.rb 376 T_STRING
7058  /Users/joerafaniello/.gem/ruby/2.2.3/gems/psych-2.0.15/lib/psych/scalar_scanner.rb  105 T_STRING
5315  /Users/joerafaniello/.gem/ruby/2.2.3/gems/psych-2.0.15/lib/psych/scalar_scanner.rb  40  T_STRING
3410  /Users/joerafaniello/.gem/ruby/2.2.3/gems/psych-2.0.15/lib/psych/scalar_scanner.rb  83  T_STRING
3260  /Users/joerafaniello/.gem/ruby/2.2.3/gems/psych-2.0.15/lib/psych/scalar_scanner.rb  54  T_STRING
3004  /Users/joerafaniello/.gem/ruby/2.2.3/gems/psych-2.0.15/lib/psych/scalar_scanner.rb  116 T_STRING
3000  /Users/joerafaniello/.gem/ruby/2.2.3/gems/psych-2.0.15/lib/psych/scalar_scanner.rb  129 T_STRING
2991  /Users/joerafaniello/.gem/ruby/2.2.3/gems/psych-2.0.15/lib/psych/scalar_scanner.rb  137 T_STRING
2401  /Users/joerafaniello/.gem/ruby/2.2.3/gems/psych-2.0.15/lib/psych/scalar_scanner.rb  126 T_STRING
1800  /Users/joerafaniello/.gem/ruby/2.2.3/gems/psych-2.0.15/lib/psych/scalar_scanner.rb  130 T_STRING
```