### PR TITLE
Avoid superclass mismatch for class Mark (TypeError)

### DIFF
--- a/lib/psych/parser.rb
+++ b/lib/psych/parser.rb
@@ -30,8 +30,7 @@ module Psych
   # construct an AST of the parsed YAML document.
 
   class Parser
-    class Mark < Struct.new(:index, :line, :column)
-    end
+    Mark = Struct.new(:index, :line, :column
 
     # The handler on which events will be called
     attr_accessor :handler


### PR DESCRIPTION
I get this stacktrace when using 'zeus' and any gem that requires 'safe_yaml'.  

It appears to me that it would be avoided by either

1) checking if the Mark constant is defined before defining it, or
2) use the 'preferred' form for defining Structs (preferred for this very reason)

```bash
$HOME/.rvm/rubies/ruby-2.2.2/lib/ruby/2.2.0/psych/parser.rb:33:in `<class:Parser>': superclass mismatch for class Mark (TypeError)
        from $HOME/.rvm/rubies/ruby-2.2.2/lib/ruby/2.2.0/psych/parser.rb:32:in `<module:Psych>'
        from $HOME/.rvm/rubies/ruby-2.2.2/lib/ruby/2.2.0/psych/parser.rb:1:in `<top (required)>'
        from $HOME/projects/rails_server/bundle/ruby/2.2.0/gems/activesupport-4.2.4/lib/active_support/dependencies.rb:274:in `require'
        from $HOME/projects/rails_server/bundle/ruby/2.2.0/gems/activesupport-4.2.4/lib/active_support/dependencies.rb:274:in `block in require'
        from $HOME/projects/rails_server/bundle/ruby/2.2.0/gems/activesupport-4.2.4/lib/active_support/dependencies.rb:240:in `load_dependency'
        from $HOME/projects/rails_server/bundle/ruby/2.2.0/gems/activesupport-4.2.4/lib/active_support/dependencies.rb:274:in `require'
        from $HOME/.rvm/rubies/ruby-2.2.2/lib/ruby/2.2.0/psych.rb:7:in `<top (required)>'
        from $HOME/projects/rails_server/bundle/ruby/2.2.0/gems/activesupport-4.2.4/lib/active_support/dependencies.rb:274:in `require'
        from $HOME/projects/rails_server/bundle/ruby/2.2.0/gems/activesupport-4.2.4/lib/active_support/dependencies.rb:274:in `block in require'
        from $HOME/projects/rails_server/bundle/ruby/2.2.0/gems/activesupport-4.2.4/lib/active_support/dependencies.rb:240:in `load_dependency'
        from $HOME/projects/rails_server/bundle/ruby/2.2.0/gems/activesupport-4.2.4/lib/active_support/dependencies.rb:274:in `require'
        from $HOME/projects/rails_server/bundle/ruby/2.2.0/gems/safe_yaml-1.0.4/lib/safe_yaml/psych_handler.rb:1:in `<top (required)>'
        from $HOME/projects/rails_server/bundle/ruby/2.2.0/gems/activesupport-4.2.4/lib/active_support/dependencies.rb:274:in `require'
        from $HOME/projects/rails_server/bundle/ruby/2.2.0/gems/activesupport-4.2.4/lib/active_support/dependencies.rb:274:in `block in require'
        from $HOME/projects/rails_server/bundle/ruby/2.2.0/gems/activesupport-4.2.4/lib/active_support/dependencies.rb:240:in `load_dependency'
        from $HOME/projects/rails_server/bundle/ruby/2.2.0/gems/activesupport-4.2.4/lib/active_support/dependencies.rb:274:in `require'
        from $HOME/projects/rails_server/bundle/ruby/2.2.0/gems/safe_yaml-1.0.4/lib/safe_yaml/load.rb:130:in `<module:SafeYAML>'
        from $HOME/projects/rails_server/bundle/ruby/2.2.0/gems/safe_yaml-1.0.4/lib/safe_yaml/load.rb:26:in `<top (required)>'
        from $HOME/projects/rails_server/bundle/ruby/2.2.0/gems/activesupport-4.2.4/lib/active_support/dependencies.rb:274:in `require'
        from $HOME/projects/rails_server/bundle/ruby/2.2.0/gems/activesupport-4.2.4/lib/active_support/dependencies.rb:274:in `block in require'
        from $HOME/projects/rails_server/bundle/ruby/2.2.0/gems/activesupport-4.2.4/lib/active_support/dependencies.rb:240:in `load_dependency'
        from $HOME/projects/rails_server/bundle/ruby/2.2.0/gems/activesupport-4.2.4/lib/active_support/dependencies.rb:274:in `require'
```