### PR TITLE
Skips multiple requires of bigdecimal and date

### DIFF
--- a/lib/psych/visitors/to_ruby.rb
+++ b/lib/psych/visitors/to_ruby.rb
@@ -70,11 +70,11 @@ module Psych
             o.value
           end
         when '!ruby/object:BigDecimal'
-          require 'bigdecimal'
+          require 'bigdecimal' unless defined? BigDecimal
           class_loader.big_decimal._load o.value
         when "!ruby/object:DateTime"
           class_loader.date_time
-          require 'date'
+          require 'date' unless defined? DateTime
           @ss.parse_time(o.value).to_datetime
         when '!ruby/encoding'
           ::Encoding.find o.value


### PR DESCRIPTION
The extra requires one pr. bigdecimal or date in the
YAML being loaded was taking a lot of time when used in
a Rails environment.

For instance it took a file containing ~10.000 big decimals
20 seconds to load, and with this change it takes 2.5 seconds